### PR TITLE
Find default editor on Debian based systems.

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,8 @@
 // Finds the default text editor based on the update-alternatives system
 // on Debian based systems.
 const find_editor_alternative = () => {
+  const fs = require('fs');
+
   // Does the symbolic link exist?
   if (fs.existsSync('/usr/bin/editor')) {
     return fs.realpathSync('/usr/bin/editor');

--- a/index.js
+++ b/index.js
@@ -1,10 +1,27 @@
 'use strict';
+
+// Finds the default text editor based on the update-alternatives system
+// on Debian based systems.
+const find_editor_alternative = () => {
+  // Does the symbolic link exist?
+  if (fs.existsSync('/usr/bin/editor')) {
+    return fs.realpathSync('/usr/bin/editor');
+  }
+
+  // It doesn't exist on any linux distribution, unfortunately.
+  return undefined;
+};
+
 module.exports = (() => {
 	const env = process.env;
 
 	if (process.platform === 'win32') {
 		return env.EDITOR || 'notepad.exe';
 	}
+
+  if (process.platform === 'linux') {
+    return env.EDITOR || find_editor_alternative() || 'vim';
+  }
 
 	return env.EDITOR || 'vim';
 })();


### PR DESCRIPTION
For Debian (GNU/Linux) based systems there is a system called [update-alternatives](https://wiki.debian.org/DebianAlternatives), which sets symbolic links for several often used applications to a user defined default application.

One such link is **/usr/bin/editor**.

A lot of linux distributions are somehow based on Debian GNU/Linux and therefore utilize the aforementioned _update-alternatives_.